### PR TITLE
Including Windows Fix

### DIFF
--- a/src/veil/zerocoin/zwallet.cpp
+++ b/src/veil/zerocoin/zwallet.cpp
@@ -13,6 +13,7 @@
 #include "validation.h"
 #include "consensus/validation.h"
 #include "shutdown.h"
+#include "boost/thread.hpp"
 
 using namespace libzerocoin;
 


### PR DESCRIPTION
Inluding `#include "boost/thread.hpp"` update in `zwallet.cpp` to allow for successful travis build for windows.